### PR TITLE
Update connection.js

### DIFF
--- a/src/connection.js
+++ b/src/connection.js
@@ -13,15 +13,15 @@ export default function observeableSocket (address) {
         .flatMap(() => fromEvent(ws, 'message'))
         .takeUntil(closeStream)
 
-    const publisher = new Promise(function(resolve) {
+    const address = new Promise(function(resolve) {
         openStream.subscribe(() =>
             resolve(message => _ws.send(JSON.stringify(message)))
         )
     })
 
     return {
-        address: function(message) {
-            publisher.then(send => send(message))
+        send: function(message) {
+            address.then(proxy => proxy(message))
         },
 
         signal: parseStream,


### PR DESCRIPTION
If you think of `send` as an alias to `map` then `publisher` should be `address` and `address` should be `send`

so, `send(address, message)`

but address is encapsulated by the library so it will be used like:

`send(message)`

this breaks the API majorly.