### PR TITLE
fix: Typings for up/down

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 [![Known Vulnerabilities](https://snyk.io/test/github/killtheliterate/observable-socket/badge.svg?targetFile=package.json)](https://snyk.io/test/github/killtheliterate/observable-socket?targetFile=package.json)
 [![Standard - JavaScript Style Guide](https://img.shields.io/badge/code%20style-standard-brightgreen.svg)](http://standardjs.com/)
 [![npm version](https://img.shields.io/npm/v/observable-socket.svg)](https://www.npmjs.com/package/observable-socket)
+[![semantic-release](https://img.shields.io/badge/%20%20%F0%9F%93%A6%F0%9F%9A%80-semantic--release-e10079.svg)](https://github.com/semantic-release/semantic-release)
 
 # observable-socket
 
@@ -103,7 +104,6 @@ a notion of "healing" a connection. Instead, when a socket drops, the
 creating a new socket, and re-wrapping `observable-socket` around it. An
 example of how this can be done:
 
-* [requirebin](http://requirebin.com/?gist=2ec1f61d5404733d6918483730170447)
 * [gist](https://gist.github.com/killtheliterate/2ec1f61d5404733d6918483730170447#file-index-js)
 
 # Bundles and packages and boxes and goodies...

--- a/package-lock.json
+++ b/package-lock.json
@@ -3918,8 +3918,7 @@
     "@types/node": {
       "version": "12.7.5",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-12.7.5.tgz",
-      "integrity": "sha512-9fq4jZVhPNW8r+UYKnxF1e2HkDWOWKM5bC2/7c9wPV835I0aOrVbS/Hw/pWPk2uKrNXQqg9Z959Kz+IYDd5p3w==",
-      "dev": true
+      "integrity": "sha512-9fq4jZVhPNW8r+UYKnxF1e2HkDWOWKM5bC2/7c9wPV835I0aOrVbS/Hw/pWPk2uKrNXQqg9Z959Kz+IYDd5p3w=="
     },
     "@types/normalize-package-data": {
       "version": "2.4.0",
@@ -3953,6 +3952,14 @@
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-1.0.1.tgz",
       "integrity": "sha512-l42BggppR6zLmpfU6fq9HEa2oGPEI8yrSPL3GITjfRInppYFahObbIQOQK3UGxEnyQpltZLaPe75046NOZQikw==",
       "dev": true
+    },
+    "@types/ws": {
+      "version": "7.2.6",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-7.2.6.tgz",
+      "integrity": "sha512-Q07IrQUSNpr+cXU4E4LtkSIBPie5GLZyyMC1QtQYRLWz701+XcoVygGUZgvLqElq1nU4ICldMYPnexlBsg3dqQ==",
+      "requires": {
+        "@types/node": "*"
+      }
     },
     "@types/yargs": {
       "version": "13.0.2",

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
   },
   "license": "MIT",
   "dependencies": {
+    "@types/ws": "^7.2.6",
     "debug": "^4.1.1",
     "rxjs": "^6.6.3"
   },

--- a/src/__tests__/down.test.ts
+++ b/src/__tests__/down.test.ts
@@ -22,11 +22,11 @@ class WS extends EventEmitter {
 describe('down', function () {
   it('observes messages', function (done) {
     const ws = new WS()
-    const socket = create(ws)
+    const socket = create(ws as unknown as WebSocket)
 
     socket.down.pipe(take(1))
       .subscribe(
-        (el: number) => expect(el).toEqual(1),
+        (el) => expect(el).toEqual(1),
         done,
         noop
       )
@@ -46,7 +46,7 @@ describe('down', function () {
 
   it('completes', function (done) {
     const ws = new WS()
-    const socket = create(ws)
+    const socket = create(ws as unknown as WebSocket)
 
     socket.down
       .subscribe(
@@ -60,7 +60,7 @@ describe('down', function () {
 
   it('wraps errors', function (done) {
     const ws = new WS()
-    const socket = create(ws)
+    const socket = create(ws as unknown as WebSocket)
 
     socket.down
       .subscribe(

--- a/src/__tests__/down.test.ts
+++ b/src/__tests__/down.test.ts
@@ -11,7 +11,7 @@ import { create } from '../index'
 
 // ---------------------------------------------------------------------------
 
-const sum = (acc: any, el: any) => acc + el
+const sum = (acc: number, msg: MessageEvent) => acc + parseInt(msg.data, 10)
 const noop = () => null
 
 class WS extends EventEmitter {
@@ -26,7 +26,10 @@ describe('down', function () {
 
     socket.down.pipe(take(1))
       .subscribe(
-        (el) => expect(el).toEqual(1),
+        (msg) => {
+          const el = parseInt(msg.data, 10)
+          expect(el).toEqual(1)
+        },
         done,
         noop
       )
@@ -38,9 +41,9 @@ describe('down', function () {
         () => done()
       )
 
-    ws.emit('message', 1)
-    ws.emit('message', 2)
-    ws.emit('message', 3)
+    ws.emit('message', { data: '1' })
+    ws.emit('message', { data: '2' })
+    ws.emit('message', { data: '3' })
     ws.emit('close')
   })
 

--- a/src/__tests__/up.test.ts
+++ b/src/__tests__/up.test.ts
@@ -6,8 +6,8 @@ import { create } from '../index'
 
 // ---------------------------------------------------------------------------
 
-const send = (socket: any, msg: string) => socket.up(msg)
-const noop = (..._args: any[]) => undefined
+const send = (socket: ReturnType<typeof create>, msg: string) => socket.up(msg)
+const noop = (..._args: unknown[]) => null
 
 class WS extends EventEmitter {
   readyState = 1
@@ -27,7 +27,7 @@ describe('up', function () {
 
     const socket = create(ws as unknown as WebSocket)
 
-    send(socket, 'hello human...')
+    return send(socket, 'hello human...')
   })
 
   it('waits to send messages until the socket is ready', function (done) {
@@ -40,9 +40,9 @@ describe('up', function () {
 
     const socket = create(ws as unknown as WebSocket)
 
-    send(socket, 'hello human...')
+    setTimeout(() => ws.emit('open'), 3000)
 
-    setTimeout(() => ws.emit('open'), 50)
+    return send(socket, 'hello human...')
   })
 
   it('handles errors', function (done) {

--- a/src/__tests__/up.test.ts
+++ b/src/__tests__/up.test.ts
@@ -25,7 +25,7 @@ describe('up', function () {
       done()
     }
 
-    const socket = create(ws)
+    const socket = create(ws as unknown as WebSocket)
 
     send(socket, 'hello human...')
   })
@@ -38,7 +38,7 @@ describe('up', function () {
       done()
     }
 
-    const socket = create(ws)
+    const socket = create(ws as unknown as WebSocket)
 
     send(socket, 'hello human...')
 
@@ -54,7 +54,7 @@ describe('up', function () {
       throw new Error('blech')
     }
 
-    const socket = create(ws)
+    const socket = create(ws as unknown as WebSocket)
 
     send(socket, 'hello human...').catch((err: { message: string }) => {
       expect(err.message).toEqual('blech')


### PR DESCRIPTION
BREAKING CHANGE: Types for up/down are now enforced

type MessageType =
  | ArrayBufferLike
  | ArrayBufferView
  | Blob
  | string // you probably want this

up: (message: MessageType) => ...
down: Observable<WebSocket.MessageEvent> => ...